### PR TITLE
Some changes for ya

### DIFF
--- a/EE1/system/plugins/pi.encode_decode.php
+++ b/EE1/system/plugins/pi.encode_decode.php
@@ -32,7 +32,7 @@ class encode_decode {
 					$string = html_entity_decode($str);
 				} elseif ($style == "uuencode") {
 					$string = convert_uudecode($str);
-				} elseif ($style == "rawurlencode") {
+				} elseif ($style == "rawurl") {
 					$string = rawurldecode($str);
 				} else {
 					$string = urldecode($str);
@@ -43,7 +43,7 @@ class encode_decode {
 				} elseif ($style == "htmlspecialchars") {
 					$string = htmlspecialchars($str);
 				} elseif ($style == "htmlentities") {
-					$string = htmlentities($str);
+					$string = htmlentities($str, ENT_COMPAT, "UTF-8", false);
 				} elseif ($style == "uuencode") {
 					$string = convert_uuencode($str);
 				} elseif ($style == "rawurl") {

--- a/EE2/system/third_party/encode_decode/pi.encode_decode.php
+++ b/EE2/system/third_party/encode_decode/pi.encode_decode.php
@@ -87,7 +87,7 @@ class Encode_decode {
 						$string = htmlspecialchars($string);
 						break;
 					case "htmlentities":
-						$string = htmlentities($string);
+						$string = htmlentities($string, ENT_COMPAT, "UTF-8", false);
 						break;
 					case "uu":
 						$string = convert_uuencode($string);


### PR DESCRIPTION
As threatened ( :p ) here: http://getsatisfaction.com/nine_four/topics/encode_decodes_php_functions_appear_to_be_mixed_up#reply_6565181

Added charset=UTF-8 and particularly the double_encode=false parameters to htmlentities() function. This resulted in the output I was expecting:

Test:
{exp:encode_decode style="htmlentities" direction="encode"}

<form action="https://www.paypal.com/cgi-bin/webscr" method="post">
</form>

{/exp:encode_decode}

Before:
&lt;form action=&quot;https:&amp;#47;&amp;#47;www.paypal.com&amp;#47;cgi-bin&amp;#47;webscr&quot; method=&quot;post&quot;&gt;
&lt;&amp;#47;form&gt;

After:
&lt;form action=&quot;https://www.paypal.com/cgi-bin/webscr&quot; method=&quot;post&quot;&gt;
&lt;/form&gt;
